### PR TITLE
Add API & SDK Reference docs

### DIFF
--- a/api-reference/authentication.mdx
+++ b/api-reference/authentication.mdx
@@ -1,0 +1,34 @@
+---
+title: "Authentication"
+description: "API key setup and authentication for the SimLab API"
+---
+
+All API requests require an API key passed via the `API-Key` header.
+
+```
+API-Key: <your-api-key>
+```
+
+## Obtaining a Key
+
+**Via the CLI:**
+
+```bash
+collinear auth login
+```
+
+This stores the key in `~/.config/collinear/config.toml`.
+
+**Via environment variable:**
+
+```bash
+export COLLINEAR_API_KEY="<your-api-key>"
+```
+
+## Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| `401` | Invalid or missing API key |
+| `403` | Key valid but insufficient permissions |
+| `503` | Service temporarily unavailable |

--- a/api-reference/runs.mdx
+++ b/api-reference/runs.mdx
@@ -1,0 +1,59 @@
+---
+title: "Runs"
+description: "Launch agent evaluation runs (rollouts)"
+---
+
+**Base URL:** `https://simlab-api.collinear.ai`
+
+## Launch Runs
+
+Start a batch of rollouts (agent evaluation runs) for one or more tasks.
+
+```
+POST /runs
+```
+
+**Request body:**
+
+```json
+{
+  "scenario_id": "hr_recruiting",
+  "task_ids": ["hr-102", "hr-103"],
+  "rollout_count": 3,
+  "model_config": {
+    "model": "gpt-4o",
+    "provider": "openai",
+    "max_steps": 20
+  },
+  "task_overrides": {
+    "hr-102": {
+      "name": "Custom task name",
+      "description": "Custom description",
+      "rubric_markdown": "# Custom rubric..."
+    }
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `scenario_id` | `string` | Yes | Scenario to run against |
+| `task_ids` | `list[string]` | Yes | Tasks to evaluate |
+| `rollout_count` | `int` | No | Number of rollouts per task (default: 1) |
+| `model_config` | `object` | No | Model, provider, and step limit |
+| `task_overrides` | `object` | No | Per-task overrides for name, description, or rubric |
+
+**Response:** `200 OK`
+
+```json
+{
+  "run_id": "run_abc123",
+  "rollouts": [
+    {
+      "rollout_id": "rol_001",
+      "task_id": "hr-102",
+      "status": "queued"
+    }
+  ]
+}
+```

--- a/api-reference/scenarios.mdx
+++ b/api-reference/scenarios.mdx
@@ -1,0 +1,144 @@
+---
+title: "Scenarios"
+description: "List scenarios, tasks, rubrics, and NPC profiles"
+---
+
+**Base URL:** `https://simlab-api.collinear.ai`
+
+## List Scenarios
+
+List all available scenarios (domains).
+
+```
+GET /scenarios
+```
+
+**Response:** `200 OK`
+
+```json
+[
+  {
+    "scenario_id": "hr_recruiting",
+    "name": "HR Recruiting Tasks",
+    "description": "End-to-end recruiting workflow tasks",
+    "num_tasks": 12,
+    "num_npcs": 10,
+    "tool_servers": [
+      { "name": "hrms", "server_type": "http" },
+      { "name": "email", "server_type": "http" }
+    ]
+  }
+]
+```
+
+## List Tasks for a Scenario
+
+Get all tasks within a scenario, including instructions, tool server config, rubrics, and seed data.
+
+```
+GET /scenarios/{scenario_id}/tasks
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `scenario_id` | string | Scenario identifier (e.g. `hr_recruiting`) |
+
+**Response:** `200 OK`
+
+```json
+{
+  "scenario_id": "hr_recruiting",
+  "tasks": [
+    {
+      "task_id": "hr-102",
+      "name": "Schedule Initial Candidate Screening",
+      "version": "1.0",
+      "category": "recruiting",
+      "difficulty": "medium",
+      "description": "Schedule an initial screening call with the candidate...",
+      "tool_servers": [
+        { "name": "email", "tool_server_url": "https://<environment-url>/email" },
+        { "name": "calendar", "tool_server_url": "https://<environment-url>/calendar" }
+      ],
+      "task_context": "The candidate applied for a Senior Engineer role...",
+      "rubric": {
+        "task_id": "hr-102",
+        "title": "Schedule Initial Candidate Screening",
+        "overview": "Verify the agent correctly schedules...",
+        "primary_requirements": ["Send calendar invite", "Notify recruiter"],
+        "success_criteria": ["Calendar event created with correct time"],
+        "scoring": [
+          { "label": "Full Credit", "description": "All requirements met" },
+          { "label": "Partial Credit", "description": "Calendar created but no notification" },
+          { "label": "No Credit", "description": "Task not completed" }
+        ]
+      },
+      "npc_profiles": [
+        {
+          "profile_id": "lisa-anderson",
+          "first_name": "Lisa",
+          "last_name": "Anderson",
+          "email": "lisa.anderson@techcorp.com",
+          "occupation": "VP of HR / CHRO"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Get Task Rubric
+
+Get the evaluation rubric for a specific task.
+
+```
+GET /scenarios/{scenario_id}/tasks/{task_id}/rubric
+```
+
+**Response:** `200 OK`
+
+```json
+{
+  "task_id": "hr-102",
+  "title": "Schedule Initial Candidate Screening",
+  "overview": "Verify the agent correctly schedules a screening call...",
+  "primary_requirements": ["Send calendar invite to candidate", "Notify recruiting team"],
+  "success_criteria": ["Calendar event exists with correct attendees and time"],
+  "validation_steps": ["Check calendar for new event", "Check email outbox"],
+  "quality_criteria": ["Professional tone in email"],
+  "notes": "Agent should not double-book the time slot",
+  "scoring": [
+    { "label": "Full Credit", "description": "All requirements met" },
+    { "label": "Partial Credit", "description": "Partial completion" },
+    { "label": "No Credit", "description": "Task not completed" }
+  ]
+}
+```
+
+## List NPC Profiles
+
+Get the NPC (Non-Playable Character) profiles for a scenario. NPCs are simulated users that interact with the agent in real time (e.g., a hiring manager who responds to messages).
+
+```
+GET /scenarios/{scenario_id}/npcs
+```
+
+**Response:** `200 OK`
+
+```json
+{
+  "scenario_id": "hr_recruiting",
+  "npc_profiles": [
+    {
+      "profile_id": "lisa-anderson",
+      "first_name": "Lisa",
+      "last_name": "Anderson",
+      "email": "lisa.anderson@techcorp.com",
+      "occupation": "VP of HR / CHRO",
+      "public_info": "15 years in HR leadership..."
+    }
+  ]
+}
+```

--- a/api-reference/sdk/base-agent.mdx
+++ b/api-reference/sdk/base-agent.mdx
@@ -1,0 +1,85 @@
+---
+title: "BaseAgent"
+description: "The core contract for building custom agents"
+---
+
+The SDK provides a contract for building custom agents. Install via:
+
+```bash
+pip install collinear-gym
+```
+
+## Contract
+
+Your agent extends `BaseAgent` and implements four methods:
+
+```python
+from collinear_gym.agents import BaseAgent, BasePlayground, RunArtifacts, ToolCall
+
+class MyAgent(BaseAgent):
+    @staticmethod
+    def name() -> str:
+        return "my-agent"
+
+    def version(self) -> str | None:
+        return "1.0.0"
+
+    def setup(self, playground: BasePlayground) -> None:
+        """Called once before run(). Use to discover tools, warm up models, etc."""
+        self.tools = playground.list_tools()
+
+    def run(
+        self,
+        instruction: str,
+        playground: BasePlayground,
+        context: RunArtifacts,
+    ) -> None:
+        """Execute the task using a think-act-observe loop."""
+        # 1. Send the instruction to your LLM along with available tools
+        messages = [{"role": "user", "content": instruction}]
+        context.record_message("user", instruction)
+
+        max_steps = context.max_steps or 20
+        for step in range(max_steps):
+            # 2. Think — ask your LLM to decide the next action
+            llm_response = self.call_llm(messages, tools=self.tools)
+
+            if llm_response.is_done:
+                # LLM decided the task is complete
+                context.set_final_observation(llm_response.text)
+                break
+
+            # 3. Act — execute the tool call the LLM chose
+            tool_call = ToolCall(
+                tool_server=llm_response.tool_server,
+                tool_name=llm_response.tool_name,
+                parameters=llm_response.parameters,
+            )
+            result = playground.call_tool(
+                tool_call.tool_server,
+                tool_call.tool_name,
+                tool_call.parameters,
+            )
+
+            # 4. Observe — record the result and feed it back to the LLM
+            context.record_tool_call(tool_call, result)
+            messages.append({"role": "assistant", "content": f"Called {tool_call.tool_name}"})
+            messages.append({"role": "tool", "content": str(result.observation)})
+```
+
+<Note>`self.call_llm()` is your own LLM integration — use any provider (OpenAI, Anthropic, etc.). The SDK is model-agnostic.</Note>
+
+## Lifecycle
+
+1. The runner calls `setup()` once, then `run()`.
+2. If the agent exceeds the timeout, the run is terminated and artifacts captured up to that point are saved.
+
+## Running Your Agent
+
+Register your agent at runtime via the CLI:
+
+```bash
+collinear tasks run -t hr-demo -m gpt-4o --agent-import-path path.to.agent:MyAgent
+```
+
+If `--agent-import-path` is omitted, the CLI uses the built-in reference agent.

--- a/api-reference/sdk/base-playground.mdx
+++ b/api-reference/sdk/base-playground.mdx
@@ -1,0 +1,38 @@
+---
+title: "BasePlayground"
+description: "The playground abstraction for interacting with tool servers"
+---
+
+The playground is the interface your agent uses to discover and call tools at runtime.
+
+## Methods
+
+| Method | Description |
+|--------|-------------|
+| `list_tools(tool_server=None)` | Returns tool definitions (all servers, or a specific one) |
+| `call_tool(tool_server, tool_name, parameters)` | Invokes a tool and returns a `ToolCallResult` |
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `tool_servers` | `dict[str, str]` | Mapping of server names to base URLs |
+
+## HttpToolPlayground
+
+The SDK ships `HttpToolPlayground`, which implements `BasePlayground` over HTTP against the [Tool Server Protocol](/api-reference/tool-server-protocol).
+
+```python
+from collinear_gym.agents import HttpToolPlayground
+
+env = HttpToolPlayground(
+    tool_servers={
+        "email": "https://<environment-url>/email",
+        "calendar": "https://<environment-url>/calendar",
+    },
+    timeout_seconds=30.0,
+)
+
+tools = env.list_tools()
+result = env.call_tool("email", "send_email", {"to": "...", "subject": "...", "body": "..."})
+```

--- a/api-reference/sdk/run-artifacts.mdx
+++ b/api-reference/sdk/run-artifacts.mdx
@@ -1,0 +1,55 @@
+---
+title: "RunArtifacts"
+description: "The data object agents populate during execution"
+---
+
+`RunArtifacts` is the structured record of an agent run. Your agent populates it during execution, and verifiers consume it to evaluate task completion.
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | `str` | Yes | Schema version (currently `"0.1"`) |
+| `task_id` | `str` | Yes | Task identifier |
+| `task` | `str` | Yes | Task instruction text |
+| `model` | `str` | No | Model used (e.g., `"gpt-4o"`) |
+| `provider` | `str` | No | Model provider (e.g., `"openai"`) |
+| `messages` | `list[dict]` | No | Full message history (role + content) |
+| `tool_calls` | `list[ToolCall]` | No | All tool invocations made |
+| `tool_results` | `list[ToolCallResult]` | No | Results from each tool call (parallel to `tool_calls`) |
+| `metadata` | `dict` | No | Arbitrary metadata |
+| `final_observation` | `str` | No | Agent's final output/summary |
+| `error` | `str` | No | Error message if the run failed |
+| `steps_taken` | `int` | Yes | Number of tool calls executed |
+| `max_steps` | `int` | No | Step limit (if configured) |
+| `created_at` | `str` | Yes | ISO 8601 timestamp |
+
+## Helper Methods
+
+| Method | Description |
+|--------|-------------|
+| `record_message(role, content)` | Append a message to the history |
+| `record_tool_call(call, result)` | Record a tool call + result, increments `steps_taken` |
+| `set_final_observation(text)` | Set the agent's final output |
+| `set_error(text)` | Record an error |
+| `to_dict()` | Serialize to a JSON-compatible dict |
+| `dump(path)` | Write artifacts to a JSON file |
+
+## ToolCall
+
+```python
+@dataclass
+class ToolCall:
+    tool_server: str          # e.g. "email"
+    tool_name: str            # e.g. "send_email"
+    parameters: dict[str, Any]  # tool-specific parameters
+```
+
+## ToolCallResult
+
+```python
+@dataclass
+class ToolCallResult:
+    observation: Any          # response from the tool server
+    is_error: bool = False    # True if the tool call failed
+```

--- a/api-reference/task-generation.mdx
+++ b/api-reference/task-generation.mdx
@@ -1,0 +1,124 @@
+---
+title: "Task Generation"
+description: "Generate task bundles from tool definitions"
+---
+
+**Base URL:** `https://simlab-api.collinear.ai`
+
+Generate task bundles (instructions, rubrics, verifiers) from your tool definitions. Task generation is asynchronous — submit a job, poll for status, then download results.
+
+## Submit a Task Generation Job
+
+```
+POST /task-gen
+```
+
+**Request body:**
+
+```json
+{
+  "tools": [
+    {
+      "name": "send_email",
+      "description": "Send an email to the specified recipient.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "to": { "type": "string" },
+          "subject": { "type": "string" },
+          "body": { "type": "string" }
+        },
+        "required": ["to", "subject", "body"]
+      }
+    }
+  ],
+  "num_tasks": 10,
+  "model": "claude-sonnet-4-6",
+  "preset": "recruiting",
+  "complexity": { "easy": 0.3, "medium": 0.5, "hard": 0.2 }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tools` | `list[object]` | Yes | MCP tool definitions (JSON from a `/tools` endpoint) |
+| `num_tasks` | `int` | No | Number of tasks to generate (default: 10, max: 200) |
+| `model` | `string` | No | LLM model for generation (default: `claude-sonnet-4-6`) |
+| `preset` | `string` | No | Built-in preset (e.g. `"recruiting"`) — auto-fills agent, domain, workflows |
+| `agent` | `object` | No | Agent identity: `{ "role": "...", "description": "..." }` |
+| `domain` | `object` | No | Domain context: `{ "name": "...", "conventions": "...", "policies": [...] }` |
+| `categories` | `list[object]` | No | Task categories: `[{ "id": "...", "label": "..." }]` |
+| `workflows` | `list[object]` | No | Example workflows: `[{ "name": "...", "steps": ["..."] }]` |
+| `stakeholders` | `list[object]` | No | Stakeholder roles: `[{ "role": "...", "typical_asks": "..." }]` |
+| `environment` | `object` | No | Branding: `{ "email_domain": "...", "agent_email": "..." }` |
+| `complexity` | `object` | No | Difficulty distribution: `{ "easy": 0.3, "medium": 0.5, "hard": 0.2 }` |
+| `diversity` | `object` | No | Diversity config for scenario variation |
+
+**Response:** `200 OK`
+
+```json
+{
+  "job_id": "tg_abc123",
+  "status": "pending",
+  "progress": null,
+  "created_at": "2026-03-07T06:20:00Z"
+}
+```
+
+## Check Job Status
+
+```
+GET /task-gen/{job_id}
+```
+
+**Response:** `200 OK`
+
+```json
+{
+  "job_id": "tg_abc123",
+  "status": "running",
+  "progress": "Step 4/10: formatting tasks",
+  "created_at": "2026-03-07T06:20:00Z"
+}
+```
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Job queued, not yet started |
+| `running` | Generation in progress |
+| `completed` | Results ready for download |
+| `failed` | Generation failed (see `error` field) |
+
+## Download Results
+
+```
+GET /task-gen/{job_id}/results
+```
+
+**Response:** `200 OK` (only when status is `completed`)
+
+```json
+{
+  "job_id": "tg_abc123",
+  "tasks": [
+    { "filename": "task_001.json", "content": "{ ... }" }
+  ],
+  "instructions": [
+    { "filename": "task_001_instruction.md", "content": "..." }
+  ],
+  "rubrics": [
+    { "filename": "task_001_rubric.md", "content": "..." }
+  ],
+  "verifiers": [
+    { "filename": "task_001_verifier.py", "content": "..." }
+  ]
+}
+```
+
+Returns `202` if the job is still running, `404` if not found, `500` if the job failed.
+
+**CLI shortcut:**
+
+```bash
+collinear tasks-gen run --config config.toml --num-tasks 10
+```

--- a/api-reference/tool-server-protocol.mdx
+++ b/api-reference/tool-server-protocol.mdx
@@ -1,0 +1,78 @@
+---
+title: "Tool Server Protocol"
+description: "HTTP interface that all tool servers expose"
+---
+
+Every tool server (coding, email, calendar, etc.) exposes the same HTTP interface. This is what agents interact with at runtime.
+
+**Base URL:** Provided per-task in the `tool_servers` field of the task response.
+
+## List Tools
+
+Get available tools and their parameter schemas.
+
+```
+GET /tools
+```
+
+**Response:** `200 OK`
+
+```json
+{
+  "tools": [
+    {
+      "name": "send_email",
+      "description": "Send an email to the specified recipient.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "to": { "type": "string", "description": "Recipient email address" },
+          "subject": { "type": "string", "description": "Email subject line" },
+          "body": { "type": "string", "description": "Email body text" }
+        },
+        "required": ["to", "subject", "body"]
+      }
+    }
+  ]
+}
+```
+
+## Execute a Tool
+
+Invoke a tool action and get the result.
+
+```
+POST /step
+```
+
+**Request body:**
+
+```json
+{
+  "action": {
+    "tool_name": "send_email",
+    "parameters": {
+      "to": "candidate@example.com",
+      "subject": "Interview Scheduling",
+      "body": "Hello, we'd like to schedule..."
+    }
+  }
+}
+```
+
+**Response:** `200 OK`
+
+```json
+{
+  "observation": "Email sent successfully to candidate@example.com"
+}
+```
+
+**Error response:**
+
+```json
+{
+  "observation": "Error: invalid email address format",
+  "is_error": true
+}
+```

--- a/api-reference/verifier-output.mdx
+++ b/api-reference/verifier-output.mdx
@@ -1,0 +1,28 @@
+---
+title: "Verifier Output"
+description: "Output format from verifier evaluation"
+---
+
+After an agent run, verifiers evaluate whether the task was completed successfully. Verifiers consume [RunArtifacts](/api-reference/sdk/run-artifacts) and produce reward files.
+
+## Output Directory Structure
+
+```
+output/agent_run_{task_id}_{timestamp}/
+  artifacts.json              # Full RunArtifacts
+  verifier/
+    reward.txt                # "1" or "0"
+    reward.json               # { "reward": 1.0 }
+```
+
+## reward.json Schema
+
+```json
+{
+  "reward": 1.0
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reward` | `float` | `1.0` for success, `0.0` for failure (partial scores possible) |

--- a/mint.json
+++ b/mint.json
@@ -27,6 +27,10 @@
   },
   "tabs": [
     {
+      "name": "API Reference",
+      "url": "api-reference"
+    },
+    {
       "name": "Blog",
       "url": "https://blog.collinear.ai"
     }
@@ -57,6 +61,30 @@
         "core-concepts/task-generator",
         "core-concepts/verifiers",
         "core-concepts/npcs"
+      ]
+    },
+    {
+      "group": "API Reference",
+      "pages": [
+        "api-reference/authentication",
+        "api-reference/scenarios",
+        "api-reference/runs",
+        "api-reference/task-generation",
+        "api-reference/tool-server-protocol"
+      ]
+    },
+    {
+      "group": "Agent SDK",
+      "pages": [
+        "api-reference/sdk/base-agent",
+        "api-reference/sdk/base-playground",
+        "api-reference/sdk/run-artifacts"
+      ]
+    },
+    {
+      "group": "Verifiers",
+      "pages": [
+        "api-reference/verifier-output"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Add **API Reference** tab with 9 new pages, broken into 3 nav groups:
  - **API Reference**: Authentication, Scenarios, Runs, Task Generation, Tool Server Protocol
  - **Agent SDK**: BaseAgent, BasePlayground, RunArtifacts
  - **Verifiers**: Verifier Output
- Content sourced from internal `api-docs/API-SDK-Reference.md`

## Test plan
- [x] Preview with `mintlify dev` — verify all pages render and nav works
- [x] Check internal links between pages (e.g., RunArtifacts → Tool Server Protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)