### PR TITLE
Align docs with QUICKSTART.md and fix cross-page inconsistencies

### DIFF
--- a/simulation-lab/getting-started.mdx
+++ b/simulation-lab/getting-started.mdx
@@ -7,11 +7,11 @@ Install the CLI and run your first evaluation against a simulated environment.
 
 ## Prerequisites
 
-- Python 3.11+
-- Docker Desktop (or Docker Engine with Compose)
-- Collinear API key from [platform.collinear.ai](https://platform.collinear.ai)
-- An LLM provider API key (e.g. `OPENAI_API_KEY`)
-- Daytona API Key (optional if you want to deploy into a cloud sandbox)
+- Python 3.13
+- A Collinear API key from [platform.collinear.ai](https://platform.collinear.ai) (Developers → API Keys)
+- An API key for any [LiteLLM-supported model provider](https://docs.litellm.ai/docs/providers) (OpenAI, Anthropic, Google, etc.)
+- *(Optional)* Docker Desktop (or Docker Engine with Compose) — only required for local execution without Daytona
+- *(Optional)* A [Daytona](https://app.daytona.io) API key for remote sandbox execution
 
 ## Installation
 
@@ -19,22 +19,49 @@ Install the CLI and run your first evaluation against a simulated environment.
 uv tool install --python 3.13 "simulationlab[daytona]"
 ```
 
+The PyPI package is named `simulationlab`. The installed CLI command is `simlab`.
+
 ## Authentication
 
-All `simlab` commands require a Collinear API key. Get one from the platform dashboard (Developers → API Keys).
+Log in with your Collinear API key:
 
 ```bash
-# Option A: Global config file (recommended)
-mkdir -p ~/.config/simlab
-cat >> ~/.config/simlab/config.toml <<'EOF'
-collinear_api_key = "<your-collinear-api-key>"
-EOF
+simlab auth login
+```
 
-# Option B: Environment variable
-export SIMLAB_COLLINEAR_API_KEY="<your-collinear-api-key>"
+This saves your key to `~/.config/simlab/config.toml`.
 
-# Option C: Per-command flag
-simlab --collinear-api-key "<your-collinear-api-key>" <command>
+Then export your model provider key:
+
+```bash
+# Use whichever provider you prefer — SimLab uses LiteLLM under the hood.
+export SIMLAB_AGENT_API_KEY="your-api-key"
+
+# Optional: export Daytona key if using remote sandboxes
+export DAYTONA_API_KEY="dtn_..."
+```
+
+### Supported providers
+
+SimLab supports any [LiteLLM-compatible provider](https://docs.litellm.ai/docs/providers). Here are common examples:
+
+| Provider | Model format | `SIMLAB_AGENT_API_KEY` | Verifier `provider` value |
+|----------|-------------|------------------------|--------------------------|
+| OpenAI | `gpt-4o` | Your OpenAI API key | `openai` |
+| Anthropic | `anthropic/claude-sonnet-4-20250514` | Your Anthropic API key | `anthropic` |
+| Google | `gemini/gemini-2.5-pro` | Your Google AI API key | `gemini` |
+
+The model format follows LiteLLM conventions: `<provider>/<model_name>`. OpenAI models don't require the provider prefix since it's the default.
+
+**Full example using Anthropic:**
+
+```bash
+export SIMLAB_AGENT_API_KEY="sk-ant-..."
+
+simlab tasks run --env my-env \
+  --task hr__0_weaver_flag_biased_compensation_adjustment_request \
+  --agent-model anthropic/claude-sonnet-4-20250514 \
+  --agent-api-key "$SIMLAB_AGENT_API_KEY"
 ```
 
 ## Starting an environment
@@ -46,11 +73,7 @@ Initialize an environment from a template and start it:
 simlab env init my-env --template hr
 ```
 
-To pick tools interactively instead of using a template:
-
-```bash
-simlab env init my-env
-```
+> To see all available templates: `simlab templates list`
 
 ## Choosing a task
 
@@ -59,9 +82,6 @@ Tasks are organized by the scenario template associated with your environment.
 ```bash
 # List tasks for your environment's template
 simlab tasks list --env my-env
-
-# View details for a specific task
-simlab tasks info --env my-env --task ar-100-schedule-phone-screen
 ```
 
 If you generated tasks locally (via `tasks-gen`), browse them directly:
@@ -72,42 +92,66 @@ simlab tasks list --tasks-dir ./generated-tasks
 
 ## Running a rollout
 
-The primary command is `simlab tasks run`.
+The primary command is `simlab tasks run`. It automatically starts the environment, seeds data, runs the agent, verifies the result, and tears down when done.
 
-**Built-in reference agent (default).** Uses [LiteLLM](https://docs.litellm.ai/) and supports any LLM provider.
+**With Daytona (recommended — fast, ephemeral remote sandboxes):**
 
 ```bash
 simlab tasks run --env my-env \
-  --task 100_weaver_schedule_phone_screen \
-  --agent-model gpt-5.2 \
-  --agent-api-key "$OPENAI_API_KEY"
+  --task hr__0_weaver_flag_biased_compensation_adjustment_request \
+  --daytona \
+  --agent-model <model> \
+  --agent-api-key "$SIMLAB_AGENT_API_KEY"
 ```
 
-**Custom agent (recommended).**
+**Without Daytona (runs locally via Docker — first run may be slow while images pull):**
 
 ```bash
 simlab tasks run --env my-env \
-  --task ar-100-schedule-phone-screen \
+  --task hr__0_weaver_flag_biased_compensation_adjustment_request \
+  --agent-model <model> \
+  --agent-api-key "$SIMLAB_AGENT_API_KEY"
+```
+
+Use any [LiteLLM-supported model](https://docs.litellm.ai/docs/providers) for `--agent-model` (e.g. `gpt-4o`, `anthropic/claude-sonnet-4-20250514`, `gemini/gemini-2.5-pro`).
+
+**Custom agent (recommended for production use):**
+
+```bash
+simlab tasks run --env my-env \
+  --task hr__0_weaver_flag_biased_compensation_adjustment_request \
   --agent-import-path path.to.agent:MyAgent
 ```
 
-Your agent must implement the `BaseAgent` contract. See [Bring Your Own Agent](/simulation-lab/bring-your-own-agent) for the full interface.
+Custom agents use their own model configuration — `--agent-model` and `--agent-api-key` do not apply. Your agent must implement the `BaseAgent` contract. See [Bring Your Own Agent](/simulation-lab/bring-your-own-agent) for the full interface.
+
+## Viewing results
+
+Results are saved to `output/agent_run_<task_id>_<timestamp>/`:
+
+- `artifacts.json` — full rollout trace (messages, tool calls, observations)
+- `verifier/reward.txt` — `1` (pass) or `0` (fail)
+- `verifier/reward.json` — e.g. `{"reward": 1.0}`
+
+For more detail, see [Understanding Results](/simulation-lab/understanding-results).
 
 ## Configuring verifiers
 
-When a task includes LLM-as-judge verifiers, configure the judge credentials separately from the agent:
+Generated tasks use rubric-based verifiers that need a model to score results. Configure the verifier before running generated tasks:
 
 ```bash
-export SIMLAB_VERIFIER_MODEL="gpt-5.2"
-export SIMLAB_VERIFIER_PROVIDER="openai"
-export SIMLAB_VERIFIER_API_KEY="$OPENAI_API_KEY"
+export SIMLAB_VERIFIER_MODEL="<provider>/<model>"    # e.g. gpt-4o, anthropic/claude-sonnet-4-20250514
+export SIMLAB_VERIFIER_PROVIDER="<provider>"          # e.g. openai, anthropic, gemini
+export SIMLAB_VERIFIER_API_KEY="your-api-key"
 ```
 
 Or in `config.toml`:
 
 ```toml
 [verifier]
-model = "gpt-5.2"
-provider = "openai"
-api_key = "sk-..."
+model = "<provider>/<model>"
+provider = "<provider>"
+api_key = "your-api-key"
 ```
+
+> Built-in tasks use programmatic verifiers and don't require this setup. This is only needed for tasks you generate via `tasks-gen`.

--- a/simulation-lab/getting-started.mdx
+++ b/simulation-lab/getting-started.mdx
@@ -116,15 +116,7 @@ simlab tasks run --env my-env \
 
 Use any [LiteLLM-supported model](https://docs.litellm.ai/docs/providers) for `--agent-model` (e.g. `gpt-4o`, `anthropic/claude-sonnet-4-20250514`, `gemini/gemini-2.5-pro`).
 
-**Custom agent (recommended for production use):**
-
-```bash
-simlab tasks run --env my-env \
-  --task hr__0_weaver_flag_biased_compensation_adjustment_request \
-  --agent-import-path path.to.agent:MyAgent
-```
-
-Custom agents use their own model configuration — `--agent-model` and `--agent-api-key` do not apply. Your agent must implement the `BaseAgent` contract. See [Bring Your Own Agent](/simulation-lab/bring-your-own-agent) for the full interface.
+You can also run tasks with your own agent implementation instead of the built-in one. See [Bring Your Own Agent](/simulation-lab/bring-your-own-agent) for the full interface and setup.
 
 ## Viewing results
 

--- a/simulation-lab/getting-started.mdx
+++ b/simulation-lab/getting-started.mdx
@@ -10,8 +10,9 @@ Install the CLI and run your first evaluation against a simulated environment.
 - Python 3.13
 - A Collinear API key from [platform.collinear.ai](https://platform.collinear.ai) (Developers → API Keys)
 - An API key for any [LiteLLM-supported model provider](https://docs.litellm.ai/docs/providers) (OpenAI, Anthropic, Google, etc.)
-- *(Optional)* Docker Desktop (or Docker Engine with Compose) — only required for local execution without Daytona
-- *(Optional)* A [Daytona](https://app.daytona.io) API key for remote sandbox execution
+- **One of the following** for running environments:
+  - A [Daytona](https://app.daytona.io) API key — for fast, ephemeral remote sandboxes (recommended)
+  - Docker Desktop (or Docker Engine with Compose) — for local execution
 
 ## Installation
 

--- a/simulation-lab/getting-started.mdx
+++ b/simulation-lab/getting-started.mdx
@@ -16,7 +16,7 @@ Install the CLI and run your first evaluation against a simulated environment.
 ## Installation
 
 ```bash
-pip install simulationlab
+uv tool install --python 3.13 "simulationlab[daytona]"
 ```
 
 ## Authentication
@@ -42,7 +42,8 @@ simlab --collinear-api-key "<your-collinear-api-key>" <command>
 Initialize an environment from a template and start it:
 
 ```bash
-simlab env init my-env --template hr_recruiting
+# Initialize an HR-based scenario environment
+simlab env init my-env --template hr
 ```
 
 To pick tools interactively instead of using a template:

--- a/simulation-lab/scenarios.mdx
+++ b/simulation-lab/scenarios.mdx
@@ -5,21 +5,11 @@ description: "Scenario templates and composition for simulation scenarios"
 
 ## Scenario Templates
 
-Templates are named toolset combinations for common scenarios. Browse them with:
+Templates are named toolset combinations for common scenarios. Browse available templates with:
 
 ```bash
 simlab templates list
 ```
-
-| Template | Included Tools |
-|----------|---------------|
-| `hr` | Frappe HRMS, Rocket.Chat, Email, Calendar |
-| `customer-service` | Frappe Helpdesk, Rocket.Chat, Email, Calendar |
-| `coding` | OpenHands, Bash |
-| `finance` | SEC Edgar, Twelve Data, Google Workspace |
-| `personal-assistant` | OpenTable, Outlook, Weather, WhatsApp |
-
-Templates are a starting point; users can build custom combinations by selecting individual tools during `env init`.
 
 ## Scenario Composition
 

--- a/simulation-lab/scenarios.mdx
+++ b/simulation-lab/scenarios.mdx
@@ -5,11 +5,21 @@ description: "Scenario templates and composition for simulation scenarios"
 
 ## Scenario Templates
 
-Templates are named toolset combinations for common scenarios. Browse available templates with:
+Templates are named toolset combinations for common scenarios. Browse them with:
 
 ```bash
 simlab templates list
 ```
+
+| Template | Included Tools |
+|----------|---------------|
+| `hr` | Frappe HRMS, Rocket.Chat, Email, Calendar |
+| `customer-service` | Frappe Helpdesk, Rocket.Chat, Email, Calendar |
+| `coding` | OpenHands, Bash |
+| `finance` | SEC Edgar, Twelve Data, Google Workspace |
+| `personal-assistant` | OpenTable, Outlook, Weather, WhatsApp |
+
+Templates are a starting point; users can build custom combinations by selecting individual tools during `env init`.
 
 ## Scenario Composition
 

--- a/simulation-lab/scenarios.mdx
+++ b/simulation-lab/scenarios.mdx
@@ -13,7 +13,7 @@ simlab templates list
 
 | Template | Included Tools |
 |----------|---------------|
-| `human-resources` | Frappe HRMS, Rocket.Chat, Email, Calendar |
+| `hr` | Frappe HRMS, Rocket.Chat, Email, Calendar |
 | `customer-service` | Frappe Helpdesk, Rocket.Chat, Email, Calendar |
 | `coding` | OpenHands, Bash |
 | `finance` | SEC Edgar, Twelve Data, Google Workspace |

--- a/simulation-lab/tasks-and-verifiers.mdx
+++ b/simulation-lab/tasks-and-verifiers.mdx
@@ -96,7 +96,7 @@ variations = [
 ]
 ```
 
-- **`template`** — Starting template (e.g. `hr`, `coding`, `customer_support`). See `simlab tasks-gen templates` for all available templates.
+- **`template`** — See `simlab tasks-gen templates` for all available templates.
 - **`categories`** — Task categories to generate across.
 - **`[agent]`** — The role and description of the agent being evaluated.
 - **`[[toolset]]`** — Tools available to the agent, with allowed operations.

--- a/simulation-lab/tasks-and-verifiers.mdx
+++ b/simulation-lab/tasks-and-verifiers.mdx
@@ -23,7 +23,7 @@ simlab tasks-gen run --config ./taskgen/config.toml
 Here is an example config for an HR scenario:
 
 ```toml
-preset = "hr"
+template = "hr"
 categories = [
     { id = "job_requisition", label = "Job requisition" },
     { id = "shortlist_resumes", label = "Shortlist the resumes" },
@@ -96,7 +96,7 @@ variations = [
 ]
 ```
 
-- **`preset`** — Starting template. Available presets: `recruiting`, `people_mgmt`, `coding`, `customer_support`.
+- **`template`** — Starting template (e.g. `hr`, `coding`, `customer_support`). See `simlab tasks-gen templates` for all available templates.
 - **`categories`** — Task categories to generate across.
 - **`[agent]`** — The role and description of the agent being evaluated.
 - **`[[toolset]]`** — Tools available to the agent, with allowed operations.
@@ -111,6 +111,8 @@ For common domains, pre-built tasks are available via the Scenario Manager API. 
 
 ```bash
 simlab tasks list --env my-env
-simlab tasks run --env my-env --task 100_weaver_schedule_phone_screen \
-  --agent-model gpt-5.2--agent-api-key "$OPENAI_API_KEY"
+simlab tasks run --env my-env \
+  --task hr__0_weaver_flag_biased_compensation_adjustment_request \
+  --agent-model <model> \
+  --agent-api-key "$SIMLAB_AGENT_API_KEY"
 ```

--- a/simulation-lab/toolsets.mdx
+++ b/simulation-lab/toolsets.mdx
@@ -241,7 +241,8 @@ simlab env init my-env --force
 simlab tasks run --env my-env \
   --tasks-dir ./task-bundle \
   --task workspace_asset_report \
-  --agent-model gpt-5.2
+  --agent-model <model> \
+  --agent-api-key "$SIMLAB_AGENT_API_KEY"
 ```
 
 ## Task Generation with Custom Tools


### PR DESCRIPTION
## Summary
- **getting-started.mdx**: Overhauled to match [QUICKSTART.md](https://github.com/collinear-ai/simlab/blob/main/QUICKSTART.md) — `simlab auth login`, model-agnostic examples, `--daytona` flag, Docker vs Daytona as one-or-the-other prereq, supported providers table with `<provider>/<model_name>` format, output/results section
- **tasks-and-verifiers.mdx**: `preset` → `template`, fixed broken command (missing space/backslash), updated task IDs, model-agnostic examples, removed hardcoded template list
- **scenarios.mdx**: `human-resources` → `hr` template name
- **toolsets.mdx**: Model-agnostic example with `$SIMLAB_AGENT_API_KEY`